### PR TITLE
Navigate by specific number of lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Partial Navigation
 
-A plugin that allows one to set how many multiples of the screen each PageDown/PageUp button push scrolls.
+A plugin that allows one to set how many lines each Page Up/Down button push move the caret
 
 Idea stolen from here: https://stackoverflow.com/questions/27610249/intellij-idea-control-page-up-page-down-scroll-size
 
@@ -19,15 +19,17 @@ The plugin is now in [IntelliJ IDEA plugin repository](https://plugins.jetbrains
       -  Click **OK** to apply the changes and restart the IDE if prompted.
 
 ## Configuration
-1.  To reconfigure keyboard shortcuts to use actions from this plugin: 
-      -  You can read [here](https://www.jetbrains.com/help/idea/configuring-keyboard-and-mouse-shortcuts.html) how to reconfigure they keymap.
-      -  The actions of this plugin are:
-          - **Partial Page Down** - `Page Down`
-          - **Partial Page Down with Selection** - `Shift` + `Page Down`
-          - **Partial Page Up** - `Page Up`
-          - **Partial Page Up with Selection** - `Shift` + `Page Up`
-      -  What percentage of the screen is scrolled every time you use the action is configurable in the **Partial Navigation** settings page.
-      -  (Optional) Go crazy and set the multiplier to 1.5: that's 1.5 screens per key press.
+To reconfigure keyboard shortcuts to use actions from this plugin: 
+   -  You can read [here](https://www.jetbrains.com/help/idea/configuring-keyboard-and-mouse-shortcuts.html) how to reconfigure they keymap.
+   -  The actions of this plugin are:
+       - **Partial Page Down** - `Page Down`
+       - **Partial Page Down with Selection** - `Shift` + `Page Down`
+       - **Partial Page Up** - `Page Up`
+       - **Partial Page Up with Selection** - `Shift` + `Page Up`
+   -  On **Partial Navigation** settings page you can specify the number of lines the Page Up/Down should move the caret
+   is in percentage of the screen with **Percent navigation** or specific number of lines with **Static navigation** 
+   -  (Optional) Go crazy and set the multiplier to 1.5: that's 1.5 screens per key press.
+
 
 ## License
 

--- a/src/main/java/com/andreycizov/partialnav/PartialNavConfigurable.java
+++ b/src/main/java/com/andreycizov/partialnav/PartialNavConfigurable.java
@@ -6,11 +6,21 @@ import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
+import javax.swing.text.DefaultFormatterFactory;
+import javax.swing.text.NumberFormatter;
+import java.text.NumberFormat;
 
 public class PartialNavConfigurable implements Configurable {
     private JPanel panelRoot;
     private JComboBox comboPageUpMult;
     private JComboBox comboPageDownMult;
+    private JRadioButton multiNavigationRadioButton;
+    private JRadioButton staticNavigationRadioButton;
+    private JFormattedTextField fieldPageUpStatic;
+    private JFormattedTextField fieldPageDownStatic;
+    static String navigationTypePropertyName = "com.andreycizov.partialpagenav.nav.type";
+    static String MULT = "mult";
+    static String STATIC = "static";
 
     @Nls(capitalization = Nls.Capitalization.Title)
     @Override
@@ -21,10 +31,23 @@ public class PartialNavConfigurable implements Configurable {
     @Nullable
     @Override
     public JComponent createComponent() {
-        float a = PropertiesComponent.getInstance().getFloat(PartialPageUpAction.propertyName, PartialPageUpAction.propertyDefault);
-        float b = PropertiesComponent.getInstance().getFloat(PartialPageDownAction.propertyName, PartialPageDownAction.propertyDefault);
-        comboPageUpMult.setSelectedItem(Float.toString(a));
-        comboPageDownMult.setSelectedItem(Float.toString(b));
+        fieldPageUpStatic.setFormatterFactory(new DefaultFormatterFactory(new NumberFormatter(NumberFormat.getIntegerInstance())));
+        fieldPageDownStatic.setFormatterFactory(new DefaultFormatterFactory(new NumberFormatter(NumberFormat.getIntegerInstance())));
+
+        PropertiesComponent props = PropertiesComponent.getInstance();
+        float multPageUp = props.getFloat(PartialPageUpAction.multPropertyName, PartialPageUpAction.multPropertyDefault);
+        float multPageDown = props.getFloat(PartialPageDownAction.multPropertyName, PartialPageDownAction.multPropertyDefault);
+        int staticPageUp = props.getInt(PartialPageUpAction.staticPropertyName, PartialPageUpAction.staticPropertyDefault);
+        int staticPageDown = props.getInt(PartialPageDownAction.staticPropertyName, PartialPageDownAction.staticPropertyDefault);
+        comboPageUpMult.setSelectedItem(Float.toString(multPageUp));
+        comboPageDownMult.setSelectedItem(Float.toString(multPageDown));
+        fieldPageUpStatic.setValue(staticPageUp);
+        fieldPageDownStatic.setValue(staticPageDown);
+        if (props.getValue(navigationTypePropertyName, MULT).equals(MULT)) {
+            multiNavigationRadioButton.setSelected(true);
+        } else {
+            staticNavigationRadioButton.setSelected(true);
+        }
 
         return panelRoot;
     }
@@ -39,35 +62,66 @@ public class PartialNavConfigurable implements Configurable {
     public void apply() {
         String pageUpMult = (String) comboPageUpMult.getSelectedItem();
         String pageDownMult = (String) comboPageDownMult.getSelectedItem();
+        String pageUpStatic = fieldPageUpStatic.getText();
+        String pageDownStatic = fieldPageDownStatic.getText();
 
         float fPageUpMult = Float.parseFloat(pageUpMult);
         float fPageDownMult = Float.parseFloat(pageDownMult);
+        int fPageUpStatic = Integer.parseInt(pageUpStatic);
+        int fPageDownStatic = Integer.parseInt(pageDownStatic);
 
-        PropertiesComponent.getInstance().setValue(PartialPageUpAction.propertyName, fPageUpMult, PartialPageUpAction.propertyDefault);
-        PropertiesComponent.getInstance().setValue(PartialPageDownAction.propertyName, fPageDownMult, PartialPageDownAction.propertyDefault);
+        PropertiesComponent props = PropertiesComponent.getInstance();
+        props.setValue(PartialPageUpAction.multPropertyName, fPageUpMult, PartialPageUpAction.multPropertyDefault);
+        props.setValue(PartialPageDownAction.multPropertyName, fPageDownMult, PartialPageDownAction.multPropertyDefault);
+        props.setValue(PartialPageUpAction.staticPropertyName, fPageUpStatic, PartialPageUpAction.staticPropertyDefault);
+        props.setValue(PartialPageDownAction.staticPropertyName, fPageDownStatic, PartialPageDownAction.staticPropertyDefault);
+        props.setValue(navigationTypePropertyName, multiNavigationRadioButton.isSelected() ? MULT : STATIC);
     }
 
     @Override
     public boolean isModified() {
-        float a = PropertiesComponent.getInstance().getFloat(PartialPageUpAction.propertyName, PartialPageUpAction.propertyDefault);
-        float b = PropertiesComponent.getInstance().getFloat(PartialPageDownAction.propertyName, PartialPageDownAction.propertyDefault);
+        PropertiesComponent props = PropertiesComponent.getInstance();
+        float propPageUpMult = props.getFloat(PartialPageUpAction.multPropertyName, PartialPageUpAction.multPropertyDefault);
+        float propPageDownMult = props.getFloat(PartialPageDownAction.multPropertyName, PartialPageDownAction.multPropertyDefault);
+        int propPageUpStatic = props.getInt(PartialPageUpAction.staticPropertyName, PartialPageUpAction.staticPropertyDefault);
+        int propPageDownStatic = props.getInt(PartialPageDownAction.staticPropertyName, PartialPageDownAction.staticPropertyDefault);
+        String propNavigationType = props.getValue(navigationTypePropertyName, MULT);
 
         String pageUpMult = (String) comboPageUpMult.getSelectedItem();
         String pageDownMult = (String) comboPageDownMult.getSelectedItem();
-        if (pageUpMult == null || pageDownMult == null) {
+        String pageUpStatic = fieldPageUpStatic.getText();
+        String pageDownStatic = fieldPageDownStatic.getText();
+        if (pageUpMult == null || pageDownMult == null || pageUpStatic == null || pageDownStatic == null) {
             return true;
         }
         float fPageUpMult = Float.parseFloat(pageUpMult);
         float fPageDownMult = Float.parseFloat(pageDownMult);
+        float fPageUpStatic = Integer.parseInt(pageUpStatic);
+        float fPageDownStatic = Integer.parseInt(pageDownStatic);
+        String navigationType = multiNavigationRadioButton.isSelected() ? MULT : STATIC;
 
-        return a != fPageUpMult || b != fPageDownMult;
+        return propPageUpMult != fPageUpMult || propPageDownMult != fPageDownMult
+                || propPageUpStatic != fPageUpStatic || propPageDownStatic != fPageDownStatic
+                || !propNavigationType.equals(navigationType);
     }
 
     @Override
     public void reset() {
-        float a = PropertiesComponent.getInstance().getFloat(PartialPageUpAction.propertyName, PartialPageUpAction.propertyDefault);
-        float b = PropertiesComponent.getInstance().getFloat(PartialPageDownAction.propertyName, PartialPageDownAction.propertyDefault);
-        comboPageUpMult.setSelectedItem(Float.toString(a));
-        comboPageDownMult.setSelectedItem(Float.toString(b));
+        PropertiesComponent props = PropertiesComponent.getInstance();
+        float propPageUpMult = props.getFloat(PartialPageUpAction.multPropertyName, PartialPageUpAction.multPropertyDefault);
+        float propPageDownMult = props.getFloat(PartialPageDownAction.multPropertyName, PartialPageDownAction.multPropertyDefault);
+        int propPageUpStatic = props.getInt(PartialPageUpAction.staticPropertyName, PartialPageUpAction.staticPropertyDefault);
+        int propPageDownStatic = props.getInt(PartialPageDownAction.staticPropertyName, PartialPageDownAction.staticPropertyDefault);
+        String propNavigationType = props.getValue(navigationTypePropertyName, MULT);
+
+        comboPageUpMult.setSelectedItem(Float.toString(propPageUpMult));
+        comboPageDownMult.setSelectedItem(Float.toString(propPageDownMult));
+        fieldPageUpStatic.setValue(propPageUpStatic);
+        fieldPageDownStatic.setValue(propPageDownStatic);
+        if (propNavigationType.equals(MULT)) {
+            multiNavigationRadioButton.setSelected(true);
+        } else {
+            staticNavigationRadioButton.setSelected(true);
+        }
     }
 }

--- a/src/main/java/com/andreycizov/partialnav/PartialNavConfigurableForm.form
+++ b/src/main/java/com/andreycizov/partialnav/PartialNavConfigurableForm.form
@@ -1,41 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.andreycizov.partialnav.PartialNavConfigurable">
-  <grid id="27dc6" binding="panelRoot" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="panelRoot" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="500" height="400"/>
+      <xy x="20" y="20" width="848" height="400"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="dd436" layout-manager="GridLayoutManager" row-count="2" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="dd436" layout-manager="GridLayoutManager" row-count="2" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
         <children>
-          <component id="7b41" class="javax.swing.JComboBox" binding="comboPageDownMult">
-            <constraints>
-              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <model>
-                <item value="0.1"/>
-                <item value="0.15"/>
-                <item value="0.25"/>
-                <item value="0.5"/>
-                <item value="0.75"/>
-                <item value="1"/>
-                <item value="1.25"/>
-                <item value="1.5"/>
-              </model>
-            </properties>
-          </component>
           <component id="9473a" class="javax.swing.JComboBox" binding="comboPageUpMult">
             <constraints>
-              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <model>
@@ -52,30 +35,87 @@
           </component>
           <component id="6f49d" class="javax.swing.JLabel">
             <constraints>
-              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <text value="Page Up Multiplier:"/>
+              <text value="Page Up (page):"/>
+            </properties>
+          </component>
+          <component id="8b75d" class="javax.swing.JRadioButton" binding="staticNavigationRadioButton" default-binding="true">
+            <constraints>
+              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <horizontalTextPosition value="10"/>
+              <text value="Static navigation"/>
+            </properties>
+          </component>
+          <component id="84b2f" class="javax.swing.JRadioButton" binding="multiNavigationRadioButton" default-binding="true">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <horizontalTextPosition value="10"/>
+              <text value="Percent navigation"/>
             </properties>
           </component>
           <component id="98673" class="javax.swing.JLabel">
             <constraints>
-              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <text value="Page Down Multiplier:"/>
+              <text value="Page Down (page):"/>
             </properties>
           </component>
-          <hspacer id="faee8">
+          <component id="7b41" class="javax.swing.JComboBox" binding="comboPageDownMult">
             <constraints>
-              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
-          </hspacer>
-          <hspacer id="4e73">
+            <properties>
+              <model>
+                <item value="0.1"/>
+                <item value="0.15"/>
+                <item value="0.25"/>
+                <item value="0.5"/>
+                <item value="0.75"/>
+                <item value="1"/>
+                <item value="1.25"/>
+                <item value="1.5"/>
+              </model>
+            </properties>
+          </component>
+          <component id="f8024" class="javax.swing.JLabel">
             <constraints>
-              <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="1" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
-          </hspacer>
+            <properties>
+              <text value="Page Down (lines):"/>
+            </properties>
+          </component>
+          <component id="808a7" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Page Up (lines):"/>
+            </properties>
+          </component>
+          <component id="51aac" class="javax.swing.JFormattedTextField" binding="fieldPageUpStatic">
+            <constraints>
+              <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="150" height="-1"/>
+              </grid>
+            </constraints>
+            <properties/>
+          </component>
+          <component id="b7e55" class="javax.swing.JFormattedTextField" binding="fieldPageDownStatic">
+            <constraints>
+              <grid row="1" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="150" height="-1"/>
+              </grid>
+            </constraints>
+            <properties/>
+          </component>
         </children>
       </grid>
       <vspacer id="12b41">
@@ -85,4 +125,10 @@
       </vspacer>
     </children>
   </grid>
+  <buttonGroups>
+    <group name="NavigationType">
+      <member id="8b75d"/>
+      <member id="84b2f"/>
+    </group>
+  </buttonGroups>
 </form>

--- a/src/main/java/com/andreycizov/partialnav/PartialPageDownAction.java
+++ b/src/main/java/com/andreycizov/partialnav/PartialPageDownAction.java
@@ -9,8 +9,13 @@ import org.jetbrains.annotations.NotNull;
 
 
 public class PartialPageDownAction extends EditorAction {
-    static String propertyName = "com.andreycizov.partialpagenav.mult.down";
-    static float propertyDefault = (float) 1.0;
+    static String multPropertyName = "com.andreycizov.partialpagenav.mult.down";
+    static float multPropertyDefault = (float) 1.0;
+    static String staticPropertyName = "com.andreycizov.partialpagenav.stat.down";
+    static int staticPropertyDefault = 80;
+    static String navigationTypePropertyName = "com.andreycizov.partialpagenav.nav.type";
+    static String MULT = "mult";
+    static String STATIC = "static";
 
     public static class Handler extends EditorActionHandler {
         public Handler() {
@@ -19,10 +24,13 @@ public class PartialPageDownAction extends EditorAction {
 
         @Override
         public void execute(@NotNull Editor editor, DataContext dataContext) {
+            PropertiesComponent prop = PropertiesComponent.getInstance();
             PartialPageNavHelper.moveCaretPageDown(
                     editor,
                     false,
-                    PropertiesComponent.getInstance().getFloat(propertyName, propertyDefault)
+                    prop.getFloat(multPropertyName, multPropertyDefault),
+                    prop.getInt(staticPropertyName, staticPropertyDefault),
+                    prop.getValue(navigationTypePropertyName, MULT)
             );
         }
 

--- a/src/main/java/com/andreycizov/partialnav/PartialPageDownWithSelectionAction.java
+++ b/src/main/java/com/andreycizov/partialnav/PartialPageDownWithSelectionAction.java
@@ -9,8 +9,13 @@ import org.jetbrains.annotations.NotNull;
 
 
 public class PartialPageDownWithSelectionAction extends EditorAction {
-    static String propertyName = "com.andreycizov.partialpagenav.mult.down";
-    static float propertyDefault = (float) 1.0;
+    static String multPropertyName = "com.andreycizov.partialpagenav.mult.down";
+    static float multPropertyDefault = (float) 1.0;
+    static String staticPropertyName = "com.andreycizov.partialpagenav.stat.down";
+    static int staticPropertyDefault = 80;
+    static String navigationTypePropertyName = "com.andreycizov.partialpagenav.nav.type";
+    static String MULT = "mult";
+    static String STATIC = "static";
 
     public static class Handler extends EditorActionHandler {
         public Handler() {
@@ -19,10 +24,13 @@ public class PartialPageDownWithSelectionAction extends EditorAction {
 
         @Override
         public void execute(@NotNull Editor editor, DataContext dataContext) {
+            PropertiesComponent prop = PropertiesComponent.getInstance();
             PartialPageNavHelper.moveCaretPageDown(
                     editor,
                     true,
-                    PropertiesComponent.getInstance().getFloat(propertyName, propertyDefault)
+                    prop.getFloat(multPropertyName, multPropertyDefault),
+                    prop.getInt(staticPropertyName, staticPropertyDefault),
+                    prop.getValue(navigationTypePropertyName, MULT)
             );
         }
 

--- a/src/main/java/com/andreycizov/partialnav/PartialPageNavHelper.java
+++ b/src/main/java/com/andreycizov/partialnav/PartialPageNavHelper.java
@@ -8,6 +8,8 @@ import org.jetbrains.annotations.NotNull;
 import java.awt.*;
 
 public class PartialPageNavHelper {
+    static String MULT = "mult";
+    static String STATIC = "static";
     //  https://github.com/JetBrains/intellij-community/blob/9c78db8af09c69c7aba7268c650449dd423422e2/platform/platform-impl/src/com/intellij/openapi/editor/actions/EditorActionUtil.java#L791
     static Rectangle getVisibleArea(@NotNull Editor editor) {
         return SystemProperties.isTrueSmoothScrollingEnabled() ? editor.getScrollingModel().getVisibleAreaOnScrollingFinished()
@@ -15,20 +17,20 @@ public class PartialPageNavHelper {
     }
 
     // https://github.com/JetBrains/intellij-community/blob/9c78db8af09c69c7aba7268c650449dd423422e2/platform/platform-impl/src/com/intellij/openapi/editor/actions/EditorActionUtil.java#L743
-    public static void moveCaretPageUp(@NotNull Editor editor, boolean isWithSelection, float mult) {
+    public static void moveCaretPageUp(@NotNull Editor editor, boolean isWithSelection, float multOffset, int staticOffset, String offsetType) {
         int lineHeight = editor.getLineHeight();
         Rectangle visibleArea = getVisibleArea(editor);
-        int linesIncrement = (int) (visibleArea.height / lineHeight * mult);
+        int linesIncrement = (int) (offsetType.equals(STATIC) ? staticOffset : (visibleArea.height / lineHeight * multOffset));
         editor.getScrollingModel().scrollVertically(visibleArea.y - visibleArea.y % lineHeight - linesIncrement * lineHeight);
         int lineShift = -linesIncrement;
         editor.getCaretModel().moveCaretRelatively(0, lineShift, isWithSelection, editor.isColumnMode(), true);
     }
 
     // https://github.com/JetBrains/intellij-community/blob/9c78db8af09c69c7aba7268c650449dd423422e2/platform/platform-impl/src/com/intellij/openapi/editor/actions/EditorActionUtil.java#L752
-    public static void moveCaretPageDown(@NotNull Editor editor, boolean isWithSelection, float mult) {
+    public static void moveCaretPageDown(@NotNull Editor editor, boolean isWithSelection, float multOffset, int staticOffset, String offsetType) {
         int lineHeight = editor.getLineHeight();
         Rectangle visibleArea = getVisibleArea(editor);
-        int linesIncrement = (int) (visibleArea.height / lineHeight * mult);
+        int linesIncrement = (int) (offsetType.equals(STATIC) ? staticOffset : (visibleArea.height / lineHeight * multOffset));
         int allowedBottom = ((EditorEx) editor).getContentSize().height - visibleArea.height;
         editor.getScrollingModel().scrollVertically(
                 Math.min(allowedBottom, visibleArea.y - visibleArea.y % lineHeight + linesIncrement * lineHeight));

--- a/src/main/java/com/andreycizov/partialnav/PartialPageUpAction.java
+++ b/src/main/java/com/andreycizov/partialnav/PartialPageUpAction.java
@@ -9,8 +9,13 @@ import org.jetbrains.annotations.NotNull;
 
 
 public class PartialPageUpAction extends EditorAction {
-    static String propertyName = "com.andreycizov.partialpagenav.mult.up";
-    static float propertyDefault = (float) 1.0;
+    static String multPropertyName = "com.andreycizov.partialpagenav.mult.up";
+    static float multPropertyDefault = (float) 1.0;
+    static String staticPropertyName = "com.andreycizov.partialpagenav.stat.up";
+    static int staticPropertyDefault = 80;
+    static String navigationTypePropertyName = "com.andreycizov.partialpagenav.nav.type";
+    static String MULT = "mult";
+    static String STATIC = "static";
 
     public static class Handler extends EditorActionHandler {
         public Handler() {
@@ -19,10 +24,13 @@ public class PartialPageUpAction extends EditorAction {
 
         @Override
         public void execute(@NotNull Editor editor, DataContext dataContext) {
+            PropertiesComponent prop = PropertiesComponent.getInstance();
             PartialPageNavHelper.moveCaretPageUp(
                     editor,
                     false,
-                    PropertiesComponent.getInstance().getFloat(propertyName, propertyDefault)
+                    prop.getFloat(multPropertyName, multPropertyDefault),
+                    prop.getInt(staticPropertyName, staticPropertyDefault),
+                    prop.getValue(navigationTypePropertyName, MULT)
             );
         }
 

--- a/src/main/java/com/andreycizov/partialnav/PartialPageUpWithSelectionAction.java
+++ b/src/main/java/com/andreycizov/partialnav/PartialPageUpWithSelectionAction.java
@@ -9,8 +9,13 @@ import org.jetbrains.annotations.NotNull;
 
 
 public class PartialPageUpWithSelectionAction extends EditorAction {
-    static String propertyName = "com.andreycizov.partialpagenav.mult.up";
-    static float propertyDefault = (float) 1.0;
+    static String multPropertyName = "com.andreycizov.partialpagenav.mult.up";
+    static float multPropertyDefault = (float) 1.0;
+    static String staticPropertyName = "com.andreycizov.partialpagenav.stat.up";
+    static int staticPropertyDefault = 80;
+    static String navigationTypePropertyName = "com.andreycizov.partialpagenav.nav.type";
+    static String MULT = "mult";
+    static String STATIC = "static";
 
     public static class Handler extends EditorActionHandler {
         public Handler() {
@@ -19,10 +24,13 @@ public class PartialPageUpWithSelectionAction extends EditorAction {
 
         @Override
         public void execute(@NotNull Editor editor, DataContext dataContext) {
+            PropertiesComponent prop = PropertiesComponent.getInstance();
             PartialPageNavHelper.moveCaretPageUp(
                     editor,
                     true,
-                    PropertiesComponent.getInstance().getFloat(propertyName, propertyDefault)
+                    prop.getFloat(multPropertyName, multPropertyDefault),
+                    prop.getInt(staticPropertyName, staticPropertyDefault),
+                    prop.getValue(navigationTypePropertyName, MULT)
             );
         }
 


### PR DESCRIPTION
This would allow setting Page Up/Down not only in percentage of page but also in specific number of lines

I found it useful with horizontal splits when pages can have different height, but cognitive expectations are to move carret on the same number of lines